### PR TITLE
Add timeout protection to GitHub Actions workflows

### DIFF
--- a/.github/workflows/marimo-pages.yml
+++ b/.github/workflows/marimo-pages.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -212,6 +213,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   release-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +46,7 @@ jobs:
 
   pypi-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - release-build
     permissions:


### PR DESCRIPTION
## Summary
- Added `timeout-minutes` to all workflow jobs to prevent runaway processes
- Notebook export/build: 30 minutes timeout
- Deployment jobs: 10 minutes timeout
- Release/publish jobs: 10 minutes timeout

## Test plan
- Workflows will continue to run as before
- Added protection against hanging processes
- Timeouts are appropriate for each job type

Generated with [Claude Code](https://claude.com/claude-code)