### PR TITLE
Fix security vulnerabilities: update vulnerable dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dependencies = [
     "mlflow[genai,mcp]>=2.19.0",
     "pina-mathlab>=0.2.1",
     "transformers[accelerate,sentencepiece,tiktoken]>=4.55.0",
+    "sqlparse>=0.5.3",
+    "diskcache>=5.6.3",
+    "pillow>=11.0.0",
+    "cryptography>=44.0.1",
+    "protobuf>=5.26.1",
+    "python-multipart>=0.0.18",
 ]
 
 [project.optional-dependencies]
@@ -46,6 +52,8 @@ llm = [
     "langchain>=0.3.0",
     "langchain-community>=0.3.0",
     "langchain-openai>=0.2.0",
+    "langchain-core>=0.3.15",
+    "langsmith>=0.2.0",
     "sentence-transformers>=5.1.0",
 ]
 openvino = [


### PR DESCRIPTION
## Summary

- Add explicit minimum version constraints for 6 vulnerable transitive dependencies in `[project.dependencies]`: `sqlparse>=0.5.3`, `diskcache>=5.6.3`, `pillow>=11.0.0`, `cryptography>=44.0.1`, `protobuf>=5.26.1`, `python-multipart>=0.0.18`
- Add `langchain-core>=0.3.15` and `langsmith>=0.2.0` to `[project.optional-dependencies].llm`

## Severity

- `pillow`, `cryptography`, `protobuf`, `python-multipart` — high
- `sqlparse`, `langsmith`, `diskcache` — medium
- `langchain-core` — low